### PR TITLE
MQTTのコネクションをデバイスごとに張るように変更

### DIFF
--- a/server/DeviceMqttClientManager.ts
+++ b/server/DeviceMqttClientManager.ts
@@ -1,0 +1,284 @@
+import mqtt from "mqtt";
+import { Logger } from "./Logger";
+
+/**
+ * デバイスごとのMQTTクライアントを管理し、LWTによる死活通知を実現するクラス
+ *
+ * 責任:
+ * - デバイスごとに専用のMQTTクライアントを作成・管理
+ * - 各クライアントにLWT（Last Will and Testament）を設定
+ * - デバイスのavailability（online/offline）をpublish
+ *
+ * LWTの動作:
+ * - 各クライアントはavailabilityトピックに"offline"をLWTとして設定
+ * - ブリッジが正常動作中: birthで"online"、deadで"offline"を明示的にpublish
+ * - ブリッジが異常終了時: MQTTブローカーがLWTを発動し、全デバイスを"offline"にする
+ *
+ * 使用例:
+ * ```
+ * const manager = new DeviceMqttClientManager(broker, options, baseTopic);
+ * manager.createClientForDevice(deviceId, deviceName); // デバイス検出時
+ * manager.publishAvailability(deviceId, deviceName, true);  // alive時
+ * manager.publishAvailability(deviceId, deviceName, false); // dead時
+ * ```
+ */
+interface DeviceClientInfo {
+  client: mqtt.MqttClient;
+  deviceName: string;
+}
+
+export class DeviceMqttClientManager {
+  private clients: Map<string, DeviceClientInfo> = new Map();
+  private readonly mqttBroker: string;
+  private readonly mqttBaseOption: mqtt.IClientOptions;
+  private readonly baseTopic: string;
+  private readonly baseClientId: string;
+
+  constructor(
+    mqttBroker: string,
+    mqttOption: mqtt.IClientOptions,
+    baseTopic: string
+  ) {
+    this.mqttBroker = mqttBroker;
+    this.mqttBaseOption = { ...mqttOption };
+    this.baseTopic = baseTopic;
+    this.baseClientId = mqttOption.clientId || "echonetlite2mqtt";
+  }
+
+  /**
+   * ブローカーが設定されているかどうか
+   */
+  get isConfigured(): boolean {
+    return this.mqttBroker !== "";
+  }
+
+  /**
+   * デバイス用のMQTTクライアントを作成・接続
+   * LWTを設定し、接続成功時にonlineをpublish
+   *
+   * @param deviceId デバイスの内部ID
+   * @param deviceName デバイスの表示名（MQTTトピックに使用）
+   */
+  createClientForDevice(deviceId: string, deviceName: string): void {
+    if (!this.isConfigured) {
+      Logger.debug("[DeviceMqtt]", "MQTT broker not configured, skipping client creation");
+      return;
+    }
+
+    if (this.clients.has(deviceId)) {
+      Logger.debug("[DeviceMqtt]", `Client already exists for ${deviceName} (${deviceId})`);
+      return;
+    }
+
+    // LWTトピックはdeviceName（人間が読みやすい名前）ベース
+    const willTopic = `${this.baseTopic}/${deviceName}/availability`;
+
+    // クライアントIDはデバイスごとに一意にする
+    const clientId = `${this.baseClientId}_dev_${deviceId}`;
+
+    const option: mqtt.IClientOptions = {
+      ...this.mqttBaseOption,
+      clientId: clientId,
+      will: {
+        topic: willTopic,
+        payload: Buffer.from("offline"),
+        qos: 1,
+        retain: true
+      }
+    };
+
+    Logger.info("[DeviceMqtt]", `Creating MQTT client for ${deviceName} (${deviceId}) with LWT on ${willTopic}`);
+
+    const client = mqtt.connect(this.mqttBroker, option);
+
+    client.on("connect", () => {
+      Logger.info("[DeviceMqtt]", `Connected for device ${deviceName} (${deviceId})`);
+      // 接続成功時にonlineをpublish
+      this.publishAvailabilityInternal(client, deviceId, deviceName, true);
+    });
+
+    client.on("error", (error) => {
+      Logger.warn("[DeviceMqtt]", `Error for device ${deviceName} (${deviceId}): ${error?.toString()}`);
+    });
+
+    client.on("close", () => {
+      Logger.debug("[DeviceMqtt]", `Connection closed for device ${deviceName} (${deviceId})`);
+    });
+
+    client.on("reconnect", () => {
+      Logger.debug("[DeviceMqtt]", `Reconnecting for device ${deviceName} (${deviceId})`);
+    });
+
+    this.clients.set(deviceId, { client, deviceName });
+  }
+
+  /**
+   * デバイス用クライアントが存在するかどうか
+   */
+  hasClient(deviceId: string): boolean {
+    return this.clients.has(deviceId);
+  }
+
+  /**
+   * availabilityをpublish
+   * クライアントが存在しない場合は何もしない
+   *
+   * @param deviceId デバイスの内部ID
+   * @param deviceName デバイスの表示名
+   * @param isOnline trueならonline、falseならoffline
+   */
+  publishAvailability(deviceId: string, deviceName: string, isOnline: boolean): void {
+    const clientInfo = this.clients.get(deviceId);
+
+    if (!clientInfo) {
+      Logger.warn("[DeviceMqtt]", `No client for device ${deviceName} (${deviceId}), cannot publish availability`);
+      return;
+    }
+
+    const { client } = clientInfo;
+
+    if (!client.connected) {
+      Logger.debug("[DeviceMqtt]", `Client not connected for ${deviceName} (${deviceId}), will publish when connected`);
+      // 接続されていない場合は接続待ちリスナーを追加
+      client.once("connect", () => {
+        this.publishAvailabilityInternal(client, deviceId, deviceName, isOnline);
+      });
+      return;
+    }
+
+    this.publishAvailabilityInternal(client, deviceId, deviceName, isOnline);
+  }
+
+  /**
+   * 内部用: availabilityを実際にpublish
+   */
+  private publishAvailabilityInternal(
+    client: mqtt.MqttClient,
+    deviceId: string,
+    deviceName: string,
+    isOnline: boolean
+  ): void {
+    const availability = isOnline ? "online" : "offline";
+    const nameTopic = `${this.baseTopic}/${deviceName}/availability`;
+
+    client.publish(nameTopic, availability, { retain: true }, (err) => {
+      if (err) {
+        Logger.warn("[DeviceMqtt]", `Failed to publish availability for ${deviceName}: ${err}`);
+      } else {
+        Logger.debug("[DeviceMqtt]", `Published ${availability} to ${nameTopic}`);
+      }
+    });
+
+    // deviceIdがdeviceNameと異なる場合、IDベースのトピックにもpublish
+    if (deviceId !== deviceName) {
+      const idTopic = `${this.baseTopic}/${deviceId}/availability`;
+      client.publish(idTopic, availability, { retain: true }, (err) => {
+        if (err) {
+          Logger.warn("[DeviceMqtt]", `Failed to publish availability for ${deviceId}: ${err}`);
+        }
+      });
+    }
+  }
+
+  /**
+   * デバイス用クライアントを破棄
+   * 正常終了時は先にofflineをpublishしてから切断
+   *
+   * @param deviceId デバイスの内部ID
+   * @param deviceName デバイスの表示名
+   */
+  destroyClientForDevice(deviceId: string, deviceName: string): void {
+    const clientInfo = this.clients.get(deviceId);
+    if (!clientInfo) {
+      return;
+    }
+
+    const { client } = clientInfo;
+
+    Logger.info("[DeviceMqtt]", `Destroying MQTT client for ${deviceName} (${deviceId})`);
+
+    // 明示的にofflineをpublishしてから切断
+    if (client.connected) {
+      this.publishAvailabilityInternal(client, deviceId, deviceName, false);
+      // publishが完了するのを少し待ってから切断
+      setTimeout(() => {
+        client.end(false, () => {
+          Logger.debug("[DeviceMqtt]", `Client ended for ${deviceName} (${deviceId})`);
+        });
+      }, 100);
+    } else {
+      client.end();
+    }
+
+    this.clients.delete(deviceId);
+  }
+
+  /**
+   * 全クライアントを破棄
+   * アプリケーション終了時に呼び出す
+   * 各デバイスにofflineをpublishしてから切断する
+   *
+   * @returns publishと切断が完了するPromise
+   */
+  destroyAll(): Promise<void> {
+    Logger.info("[DeviceMqtt]", `Destroying all ${this.clients.size} device MQTT clients`);
+
+    // 各クライアントにofflineをpublishしてから切断
+    const promises: Promise<void>[] = [];
+
+    this.clients.forEach((clientInfo, deviceId) => {
+      const { client, deviceName } = clientInfo;
+
+      if (client.connected) {
+        promises.push(
+          new Promise<void>((resolve) => {
+            // offlineをpublish
+            this.publishAvailabilityInternal(client, deviceId, deviceName, false);
+            Logger.debug("[DeviceMqtt]", `Published offline for ${deviceName} (${deviceId})`);
+
+            // publishが完了するのを少し待ってから切断
+            setTimeout(() => {
+              client.end(false, () => {
+                Logger.debug("[DeviceMqtt]", `Client ended for ${deviceName} (${deviceId})`);
+                resolve();
+              });
+            }, 50);
+          })
+        );
+      } else {
+        client.end();
+      }
+    });
+
+    this.clients.clear();
+
+    // 全クライアントの終了を待つ
+    return Promise.all(promises)
+      .then(() => {
+        Logger.info("[DeviceMqtt]", "All device MQTT clients destroyed");
+      })
+      .catch((err) => {
+        Logger.warn("[DeviceMqtt]", `Error during destroyAll: ${err}`);
+      });
+  }
+
+  /**
+   * 接続中のクライアント数を取得
+   */
+  getConnectedClientCount(): number {
+    let count = 0;
+    this.clients.forEach((clientInfo) => {
+      if (clientInfo.client.connected) {
+        count++;
+      }
+    });
+    return count;
+  }
+
+  /**
+   * 管理中のクライアント数を取得（接続状態問わず）
+   */
+  getTotalClientCount(): number {
+    return this.clients.size;
+  }
+}

--- a/server/MqttController.ts
+++ b/server/MqttController.ts
@@ -4,6 +4,7 @@ import { ApiDevice, ApiDeviceProperty, ApiDeviceSummary } from "./ApiTypes";
 import { Device } from "./Property";
 import { ElDataType, ElPropertyDescription } from "./MraTypes";
 import { Logger } from "./Logger";
+import { DeviceMqttClientManager } from "./DeviceMqttClientManager";
 
 export class MqttController
 {
@@ -12,11 +13,16 @@ export class MqttController
   readonly mqttBroker:string;
   readonly mqttOption:mqtt.IClientOptions;
   readonly baseTopic:string;
+  // デバイスごとのMQTTクライアント管理（LWT対応）
+  readonly deviceMqttClientManager: DeviceMqttClientManager;
+
   constructor(deviceStore:DeviceStore, mqttBroker:string, mqttOption:mqtt.IClientOptions, baseTopic:string){
     this.deviceStore =deviceStore;
     this.mqttBroker = mqttBroker;
     this.mqttOption = mqttOption;
     this.baseTopic = baseTopic;
+    // デバイスごとのMQTTクライアント管理を初期化
+    this.deviceMqttClientManager = new DeviceMqttClientManager(mqttBroker, mqttOption, baseTopic);
   }
 
   public ConnectionState: "Connected"|"Disconnected"|"NotConfigure" = "Disconnected";
@@ -342,24 +348,28 @@ export class MqttController
   }
 
   publishDeviceAvailability = (deviceId:string, isOnline:boolean):void =>{
-    if(this.mqttClient===undefined){
-      return;
-    }
     const foundDevice = this.deviceStore.getFromNameOrId(deviceId);
     if(foundDevice===undefined){
+      Logger.warn("[MQTT]", `publishDeviceAvailability: device not found: ${deviceId}`);
       return;
     }
 
-    const availability = isOnline ? "online" : "offline";
-    this.mqttClient.publish(`${this.baseTopic}/${foundDevice.name}/availability`, availability, {
-      retain:true
-    });
-    if(foundDevice.id !== foundDevice.name)
-    {
-      this.mqttClient.publish(`${this.baseTopic}/${foundDevice.id}/availability`, availability, {
-        retain:true
-      });
+    // デバイス専用MQTTクライアントを使用（LWT対応）
+    // クライアントがなければ作成（初回birth時）
+    if (!this.deviceMqttClientManager.hasClient(foundDevice.id)) {
+      if (isOnline) {
+        // online時のみクライアントを作成（クライアント作成時に自動でonlineをpublish）
+        this.deviceMqttClientManager.createClientForDevice(foundDevice.id, foundDevice.name);
+        return; // createClientForDevice内でonlineをpublishするので、ここではreturn
+      } else {
+        // クライアントがない状態でofflineを要求された場合は何もしない
+        Logger.debug("[MQTT]", `No client for ${foundDevice.name}, skipping offline publish`);
+        return;
+      }
     }
+
+    // 既存クライアントでavailabilityをpublish
+    this.deviceMqttClientManager.publishAvailability(foundDevice.id, foundDevice.name, isOnline);
   }
 
   publishDeviceProperties = (deviceId:string):void =>{

--- a/server/RestApiController.ts
+++ b/server/RestApiController.ts
@@ -73,7 +73,7 @@ export class RestApiController
    * デバイスのavailability情報を取得
    */
   private getDeviceAvailability(device: Device): { topic: string; state: "online" | "offline" | "unknown" } {
-    const topic = `${this.mqttBaseTopic}/${device.id}/availability`;
+    const topic = `${this.mqttBaseTopic}/${device.name}/availability`;
 
     if (!this.deviceLifecycleManager) {
       return { topic, state: "unknown" };

--- a/server/index.ts
+++ b/server/index.ts
@@ -932,3 +932,39 @@ echoNetListController.start().then(() => {
     Logger.info("[PeriodicDiscovery]", "Periodic device discovery disabled");
   }
 });
+
+// ========== シャットダウン処理 ==========
+// 正常終了時に全デバイス用MQTTクライアントをクリーンアップ
+// （LWTは発動させず、明示的にofflineをpublishしてから切断）
+
+let isShuttingDown = false;
+
+const gracefulShutdown = (signal: string): void => {
+  if (isShuttingDown) {
+    logger.output(`[Shutdown] Already shutting down, ignoring ${signal}`);
+    return;
+  }
+  isShuttingDown = true;
+
+  logger.output(`[Shutdown] Received ${signal}, starting graceful shutdown...`);
+
+  // デバイス用MQTTクライアントをすべて破棄（offlineをpublish後に切断）
+  mqttController.deviceMqttClientManager.destroyAll()
+    .then(() => {
+      logger.output(`[Shutdown] Cleanup completed, exiting...`);
+      process.exit(0);
+    })
+    .catch((err) => {
+      logger.output(`[Shutdown] Error during cleanup: ${err}`);
+      process.exit(1);
+    });
+
+  // タイムアウト: 5秒以内に完了しなければ強制終了
+  setTimeout(() => {
+    logger.output(`[Shutdown] Timeout, forcing exit...`);
+    process.exit(1);
+  }, 5000);
+};
+
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));


### PR DESCRIPTION
その他バグ修正など。

close #11 

This pull request introduces per-device MQTT client management with Last Will and Testament (LWT) support to improve device availability reporting and ensure robust cleanup on shutdown. The changes refactor the way device availability is published, create a dedicated `DeviceMqttClientManager` class, and add graceful shutdown logic to ensure all MQTT clients are properly disconnected and their statuses set to offline.

Key changes:

**Device MQTT Client Management and LWT Support**
- Introduced the `DeviceMqttClientManager` class to manage a separate MQTT client for each device, with LWT configured to automatically set device availability to "offline" if the process exits unexpectedly. This class handles creation, publishing, and cleanup of device-specific clients.
- Updated the `MqttController` to instantiate and use `DeviceMqttClientManager` for publishing device availability, replacing the previous approach of using a shared MQTT client. Availability is now published through the dedicated client, and LWT ensures correct offline status on abnormal termination. [[1]](diffhunk://#diff-ead5a9e04ad7bac302829b4c96dc0c88856db589861f88fb8d5b5383aab2c1aaR7) [[2]](diffhunk://#diff-ead5a9e04ad7bac302829b4c96dc0c88856db589861f88fb8d5b5383aab2c1aaR16-R25) [[3]](diffhunk://#diff-ead5a9e04ad7bac302829b4c96dc0c88856db589861f88fb8d5b5383aab2c1aaL345-R372)

**Graceful Shutdown and Cleanup**
- Added shutdown hooks in `server/index.ts` to ensure all device MQTT clients are destroyed properly on process termination. This includes publishing "offline" status for each device before disconnecting, with a timeout fallback for forced exit.

**Device Availability Topic Consistency**
- Changed the topic used for device availability reporting in the REST API controller to match the new convention (`<baseTopic>/<device.name>/availability`) for consistency with the new MQTT client management.